### PR TITLE
Implement interpreting remote sitelists

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This is a divergent fork of [beakerbrowser/dathttpd](https://github.com/beakerbr
 Here are the fork's current intended additional features:
 
 - [x] Provide a setting `localhost` for users running DatHTTPD on client environments, e.g. their computer. [The current implementation](https://github.com/garbados/dathttpd/commit/15302808f6dd81c23fca5544015af99ca092b597) creates hostfile entries for each site in the `sites` portion of the config, so that users can visit these sites in their browser without sending traffic over the internet and without using external DNS records. *Note: Modifying the user's hostfile (ex: /etc/hosts) requires the use of sudo or otherwise having root permissions, which is an awful lot of trust to require from a user. I'd rather find a different solution that requires fewer privileges.*
-- [ ] Provide a setting `peersites` which, if set to a truthy value, creates and peers an archive containing only a `dat.json` file whose `sites` attribute maps to the `sites` portion of your DatHTTPD config file.
-- [ ] Provide a setting `sitelists` that interprets a list of URLs (`dat://` or otherwise) as archives which contain the `sites` portion of a DatHTTPD config file as the `sites` attribute of the archive's `dat.json`.
+- [x] Provide a setting `peersites` which, if set to a truthy value, creates and peers an archive containing only a `dat.json` file whose `sites` attribute maps to the `sites` portion of your DatHTTPD config file. [The current implementation](https://github.com/garbados/dathttpd/pull/1/commits/f492e46c44dd5c9b0853117ae43b048e92d863ac) treats the server's storage directory as the archive, using a `.datignore` file to share only a `dat.json` which contains only a `sites` attribute.
+- [x] Provide a setting `sitelists` that interprets a list of URLs (`dat://` or otherwise) as archives which contain the `sites` portion of a DatHTTPD config file as the `sites` attribute of the archive's `dat.json`. [The current implementation](https://github.com/garbados/dathttpd/pull/1/commits/f492e46c44dd5c9b0853117ae43b048e92d863ac#diff-c945a46d13b34fcaff544d966cffcabaR114) collects manifests from each sitelist archive and merges their `sites` attributes into `this.remotesites`, which is then interpreted just like `this.sites`.
 - [ ] CLI commands for modifying the local config, such as the `sites` and `sitelists` attributes.
 - [ ] A substantial test suite with coverage above 80%.
 
@@ -137,6 +137,14 @@ This way, sites served by DatHTTPD will be available on your computer at their g
 ### metrics
 
 Whether to run the metrics server. Defaults to true. (Optional)
+
+### peersites
+
+Whether to peer the user's `sites` config as an archive. If set to true, DatHTTPD will print the key of the archive of the user's sitelist. Friends can use this key to include your sites on their local DatHTTPD instance.
+
+### sitelists
+
+An array of `dat://` addresses for archives with a `dat.json` file whose `sites` attribute corresponds to the `sites` portion of a DatHTTPD config. Archives specified in `sitelists` have their sites added to the users' own.
 
 ### sites
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,5 +1,6 @@
 const async = require('async')
 const express = require('express')
+const fs = require('fs')
 const greenlockExpress = require('greenlock-express')
 const hostile = require('hostile')
 const http = require('http')
@@ -21,6 +22,7 @@ const {
 // constants
 // =
 
+const DATIGNORE = ['*', '**/*', '!dat.json'].join('\n')
 const IS_DEBUG = (['debug', 'staging', 'test'].indexOf(process.env.NODE_ENV) !== -1)
 const LOCALHOST = '127.0.0.1'
 const DEFAULT_DIRECTORY = path.join(os.homedir(), '.dathttpd')
@@ -32,6 +34,7 @@ module.exports = class Server {
   constructor (options = {}) {
     this.options = options
     this.sites = this.options.sites
+    this.sitelists = this.options.sitelists || []
     this.directory = (this.options.directory ? untildify(this.options.directory) : DEFAULT_DIRECTORY)
     this.app = express()
 
@@ -48,30 +51,101 @@ module.exports = class Server {
 
     async.series([
       this.startDat.bind(this),
+      this.peerSiteList.bind(this),
+      this.resolveSiteLists.bind(this),
+      this.startSites.bind(this),
       this.startServer.bind(this)
     ], cb)
+  }
+
+  resolveSiteLists (cb) {
+    this.remotesites = {}
+    async.each(this.sitelists, (sitelist, cb) => {
+      console.log(`Downloading sitelist from ${sitelist}...`)
+
+      let key = getDatKey(sitelist)
+      async.waterfall([
+        (cb) => {
+          let dats = this.multidat.list()
+          var dat = dats.find(d => d.key.toString('hex') === key)
+          if (dat) {
+            cb(null, dat)
+          } else {
+            this.multidat.create(path.join(this.directory, key), { key }, cb)
+          }
+        },
+        (dat, cb) => {
+          dat.joinNetwork()
+          this.multidat.readManifest(dat, cb)
+        }
+      ], (err, datjson) => {
+        if (err) return cb(err)
+        console.log(`Downloaded sitelist from ${sitelist}`)
+        Object.keys(datjson.sites).forEach((hostname) => {
+          // TODO detect and handle conflicts
+          this.remotesites[hostname] = datjson.sites[hostname]
+        })
+        cb()
+      })
+    }, cb)
+  }
+
+  peerSiteList (cb) {
+    if (this.options.peersites) {
+      let joinDir = path.join.bind(path, this.directory)
+      // start peering this.sites
+      async.parallel([
+        fs.writeFile.bind(fs, joinDir('.datignore'), DATIGNORE, 'utf8'),
+        fs.writeFile.bind(fs, joinDir('dat.json'), JSON.stringify({ sites: this.sites }))
+      ], (err) => {
+        if (err) return cb(err)
+        this.multidat.create(this.directory, (err, dat) => {
+          if (err) return cb(err)
+          dat.joinNetwork()
+          dat.importFiles((err) => {
+            if (err) return cb(err)
+            console.log(`Peering sites as archive at dat://${dat.key.toString('hex')}`)
+            cb()
+          })
+        })
+      })
+    } else {
+      cb()
+    }
   }
 
   startDat (cb) {
     let toiletpath = path.join(this.directory, 'multidat.json')
     let db = toiletdb(toiletpath)
+
     Multidat(db, (err, multidat) => {
       if (err) return cb(err)
-
       this.multidat = multidat
-      var dats = this.multidat.list()
+      cb()
+    })
+  }
 
+  startSites (cb) {
+    async.parallel([
+      initSites.bind(this, this.sites),
+      initSites.bind(this, this.remotesites)
+    ], cb)
+
+    function initSites (sites, cb) {
+      var dats = this.multidat.list()
       // iterate sites
-      Object.keys(this.sites).forEach(hostname => {
+      async.each(Object.keys(sites), (hostname, cb) => {
+        let site = sites[hostname]
+        site.hostname = hostname
+        validateSiteCfg(site)
+
         function initDat (err, dat) {
-          if (err) throw err
+          if (err) return cb(err)
           dat.joinNetwork()
           metric.trackDatStats(dat, site)
           console.log('Serving', hostname, site.url)
+          cb()
         }
-        let site = this.sites[hostname]
-        site.hostname = hostname
-        validateSiteCfg(site)
 
         if (site.url) {
           // a dat site
@@ -97,10 +171,8 @@ module.exports = class Server {
 
         // add to the HTTPS server
         this.app.use(vhost(hostname, createSiteApp(site)))
-      })
-
-      cb()
-    })
+      }, cb)
+    }
   }
 
   startServer (cb) {


### PR DESCRIPTION
This is a WIP branch for implementing support for the `peersites` and `sitelists` config options.

- [x] `peersites`
- [x] `sitelists`
- [x] README updates

This PR tracks the progress of these features.